### PR TITLE
fix: use public MinIO endpoint for presigned URL generation

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -62,7 +62,7 @@ func NewApp() (*App, error) {
 	if err != nil {
 		return nil, err
 	}
-	minioSvc := storage.NewMinioStorage(minioCli, cfg.MinioBucket)
+	minioSvc := storage.NewMinioStorage(minioCli, cfg.MinioBucket, cfg.MinioPublicURL, cfg.MinioAccessKey, cfg.MinioSecretKey)
 
 	deviceRepo := repository.NewDeviceRepo(db)
 	photoRepo := repository.NewPhotoRepo(db)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,14 +7,15 @@ import (
 )
 
 type Config struct {
-	ServerAddress  string
-	DatabaseDSN    string
-	JWTSecret      string
-	MinioEndpoint  string
-	MinioAccessKey string
-	MinioSecretKey string
-	MinioUseSSL    bool
-	MinioBucket    string
+	ServerAddress   string
+	DatabaseDSN     string
+	JWTSecret       string
+	MinioEndpoint   string
+	MinioPublicURL  string
+	MinioAccessKey  string
+	MinioSecretKey  string
+	MinioUseSSL     bool
+	MinioBucket     string
 }
 
 func Load() (*Config, error) {
@@ -30,6 +31,7 @@ func Load() (*Config, error) {
 		"DATABASEDSN",
 		"JWTSECRET",
 		"MINIOENDPOINT",
+		"MINIOPUBLICURL",
 		"MINIOACCESSKEY",
 		"MINIOSECRETKEY",
 		"MINIOBUCKET",

--- a/internal/models/device.go
+++ b/internal/models/device.go
@@ -13,6 +13,9 @@ type Device struct {
 	InventoryNum  string    `gorm:"unique;not null" json:"inventory_num"`                                                                                           // Инвентарный номер
 	Type          string    `gorm:"not null" json:"type"`                                                                                                           // Тип устройства
 	Specification string    `gorm:"type:text" json:"specification"`                                                                                                 // Спецификация
+	//Нужен ли нам статус для девайсов, устройств на сервере. Что он нам дает? Какие статусы мы здесь отображаем?
+	//Сервер один, клиентов много. В каком случае нам надо менять статусы.
+	//[red flag] - рассмотреть возможность для удаления поля
 	Status        string    `gorm:"not null" json:"status"`                                                                                                         // Статус
 	UserUUID      uuid.UUID `gorm:"type:uuid;not null;index;column:user_id" json:"user_uuid" swaggertype:"string" example:"550e8400-e29b-41d4-a716-446655440000"`   // UUID владельца (из auth-сервиса)
 	CreatedAt     time.Time `json:"created_at"`                                                                                                                     // Дата создания

--- a/internal/services/photo_service.go
+++ b/internal/services/photo_service.go
@@ -87,8 +87,9 @@ func (s *photoService) GetPresignedUploadURL(ctx context.Context, objectName, co
 	// objectName может быть полным URL (minio://photos/...) или просто путём
 	// Извлекаем путь из URL
 	path := objectName
-	if len(objectName) > 13 && objectName[:13] == "minio://photos/" {
-		path = objectName[13:]
+	const prefix = "minio://photos/"
+	if len(objectName) > len(prefix) && objectName[:len(prefix)] == prefix {
+		path = objectName[len(prefix):]
 	}
 	return s.minioSVC.PresignedPutURL(ctx, path, contentType, 24*time.Hour)
 }

--- a/internal/storage/minio.go
+++ b/internal/storage/minio.go
@@ -19,8 +19,9 @@ type Storage interface {
 }
 
 type minioStorage struct {
-	client *minio.Client
-	bucket string
+	client        *minio.Client
+	presignClient *minio.Client // отдельный клиент для presigned URL (подключён к public endpoint)
+	bucket        string
 }
 
 func NewMinioClient(endpoint, accessKey, secretKey string, useSSL bool, bucket string) (*minio.Client, error) {
@@ -46,8 +47,25 @@ func NewMinioClient(endpoint, accessKey, secretKey string, useSSL bool, bucket s
 	return cli, nil
 }
 
-func NewMinioStorage(cli *minio.Client, bucket string) Storage {
-	return &minioStorage{client: cli, bucket: bucket}
+func NewMinioStorage(cli *minio.Client, bucket string, publicURL string, accessKey, secretKey string) Storage {
+	var presignClient *minio.Client
+	if publicURL != "" {
+		parsedURL, err := url.Parse(publicURL)
+		if err == nil {
+			// Определяем useSSL на основе схемы
+			useSSL := parsedURL.Scheme == "https"
+			// Создаём отдельный клиент для presigned URL, подключённый к public endpoint
+			presignClient, err = minio.New(parsedURL.Host, &minio.Options{
+				Creds:  credentials.NewStaticV4(accessKey, secretKey, ""),
+				Secure: useSSL,
+			})
+			if err != nil {
+				// Если не получилось — просто не используем presignClient
+				presignClient = nil
+			}
+		}
+	}
+	return &minioStorage{client: cli, presignClient: presignClient, bucket: bucket}
 }
 
 func (s *minioStorage) Upload(ctx context.Context, objectName string, reader io.Reader, size int64, contentType string) (minio.UploadInfo, error) {
@@ -64,7 +82,16 @@ func (s *minioStorage) PresignedGetURL(ctx context.Context, objectName string, e
 }
 
 func (s *minioStorage) PresignedPutURL(ctx context.Context, objectName, contentType string, expiry time.Duration) (string, error) {
-	// Presigned URL для PUT запроса
+	// Если есть отдельный клиент для presigned URL, используем его
+	if s.presignClient != nil {
+		u, err := s.presignClient.PresignedPutObject(ctx, s.bucket, objectName, expiry)
+		if err != nil {
+			return "", err
+		}
+		return u.String(), nil
+	}
+
+	// Фолбэк на основной клиент
 	u, err := s.client.PresignedPutObject(ctx, s.bucket, objectName, expiry)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
- Add MINIOPUBLICURL env var to config
- Create separate MinIO client connected to public endpoint for presigned URL signing
- Fix prefix length for 'minio://photos/' (was 13, should be 15)
- Add MINIOPUBLICURL to docker-compose.yml and docker-compose.dev.yml
- Leave device.go comments as-is