### PR TITLE
Создали два minio клиента для внешнего и внутреннего адреса, потому ч…

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -52,8 +52,9 @@ func NewApp() (*App, error) {
 		return nil, err
 	}
 
-	minioCli, err := storage.NewMinioClient(
-		cfg.MinioEndpoint,
+	minioSvc, err := storage.NewMinioStorage(
+		cfg.MinioEndpoint,  // внутренний: minio:9000
+		cfg.MinioPublicURL, // внешний: http://149.154.65.57:9000
 		cfg.MinioAccessKey,
 		cfg.MinioSecretKey,
 		cfg.MinioUseSSL,
@@ -62,7 +63,6 @@ func NewApp() (*App, error) {
 	if err != nil {
 		return nil, err
 	}
-	minioSvc := storage.NewMinioStorage(minioCli, cfg.MinioBucket, cfg.MinioPublicURL, cfg.MinioAccessKey, cfg.MinioSecretKey)
 
 	deviceRepo := repository.NewDeviceRepo(db)
 	photoRepo := repository.NewPhotoRepo(db)

--- a/internal/services/photo_service.go
+++ b/internal/services/photo_service.go
@@ -48,7 +48,7 @@ func (s *photoService) CreatePendingPhoto(ctx context.Context, userUUID uuid.UUI
 	photo := &models.Photo{
 		UUID:        photoUUID,
 		UserUUID:    userUUID,
-		URL:         fmt.Sprintf("minio://photos/%s", objectName),
+		URL:         objectName, // Сохраняем только относительный путь
 		Status:      models.PhotoStatusPending,
 		FileSize:    fileSize,
 		FileName:    fileName,
@@ -84,12 +84,6 @@ func (s *photoService) ListByDeviceUUID(ctx context.Context, deviceUUID uuid.UUI
 }
 
 func (s *photoService) GetPresignedUploadURL(ctx context.Context, objectName, contentType string) (string, error) {
-	// objectName может быть полным URL (minio://photos/...) или просто путём
-	// Извлекаем путь из URL
-	path := objectName
-	const prefix = "minio://photos/"
-	if len(objectName) > len(prefix) && objectName[:len(prefix)] == prefix {
-		path = objectName[len(prefix):]
-	}
-	return s.minioSVC.PresignedPutURL(ctx, path, contentType, 24*time.Hour)
+	// objectName теперь содержит чистый путь (user_id/photo_id_filename)
+	return s.minioSVC.PresignedPutURL(ctx, objectName, contentType, 24*time.Hour)
 }

--- a/internal/storage/minio.go
+++ b/internal/storage/minio.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/url"
 	"time"
 
@@ -12,93 +11,81 @@ import (
 )
 
 type Storage interface {
-	Upload(ctx context.Context, objectName string, reader io.Reader, size int64, contentType string) (minio.UploadInfo, error)
 	PresignedGetURL(ctx context.Context, objectName string, expiry time.Duration) (string, error)
 	PresignedPutURL(ctx context.Context, objectName, contentType string, expiry time.Duration) (string, error)
 	Delete(ctx context.Context, objectName string) error
 }
 
-type minioStorage struct {
-	client        *minio.Client
-	presignClient *minio.Client // отдельный клиент для presigned URL (подключён к public endpoint)
-	bucket        string
+type MinioStorage struct {
+	internalClient *minio.Client // minio:9000 — для операций
+	externalClient *minio.Client // 149.154.65.57:9000 — для presigned URL
+	bucket         string
 }
 
-func NewMinioClient(endpoint, accessKey, secretKey string, useSSL bool, bucket string) (*minio.Client, error) {
-	cli, err := minio.New(endpoint, &minio.Options{
+func NewMinioStorage(internalEndpoint, externalEndpoint, accessKey, secretKey string, useSSL bool, bucket string) (Storage, error) {
+	// Создаём внутренний клиент (для операций внутри Docker)
+	internalClient, err := minio.New(internalEndpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(accessKey, secretKey, ""),
 		Secure: useSSL,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("minio init failed: %w", err)
+		return nil, fmt.Errorf("internal client init failed: %w", err)
 	}
 
+	// Проверяем/создаём бакет через внутренний клиент
 	ctx := context.Background()
-	exists, err := cli.BucketExists(ctx, bucket)
+	exists, err := internalClient.BucketExists(ctx, bucket)
 	if err != nil {
 		return nil, fmt.Errorf("bucketExists check failed: %w", err)
 	}
 	if !exists {
-		if err := cli.MakeBucket(ctx, bucket, minio.MakeBucketOptions{}); err != nil {
+		if err := internalClient.MakeBucket(ctx, bucket, minio.MakeBucketOptions{}); err != nil {
 			return nil, fmt.Errorf("makeBucket failed: %w", err)
 		}
 	}
 
-	return cli, nil
-}
-
-func NewMinioStorage(cli *minio.Client, bucket string, publicURL string, accessKey, secretKey string) Storage {
-	var presignClient *minio.Client
-	if publicURL != "" {
-		parsedURL, err := url.Parse(publicURL)
+	// Создаём внешний клиент (для presigned URL)
+	externalUseSSL := useSSL
+	if externalEndpoint != "" {
+		parsedURL, err := url.Parse(externalEndpoint)
 		if err == nil {
-			// Определяем useSSL на основе схемы
-			useSSL := parsedURL.Scheme == "https"
-			// Создаём отдельный клиент для presigned URL, подключённый к public endpoint
-			presignClient, err = minio.New(parsedURL.Host, &minio.Options{
-				Creds:  credentials.NewStaticV4(accessKey, secretKey, ""),
-				Secure: useSSL,
-			})
-			if err != nil {
-				// Если не получилось — просто не используем presignClient
-				presignClient = nil
-			}
+			externalUseSSL = parsedURL.Scheme == "https"
+			externalEndpoint = parsedURL.Host
 		}
 	}
-	return &minioStorage{client: cli, presignClient: presignClient, bucket: bucket}
+
+	externalClient, err := minio.New(externalEndpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(accessKey, secretKey, ""),
+		Secure: externalUseSSL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("external client init failed: %w", err)
+	}
+
+	return &MinioStorage{
+		internalClient: internalClient,
+		externalClient: externalClient,
+		bucket:         bucket,
+	}, nil
 }
 
-func (s *minioStorage) Upload(ctx context.Context, objectName string, reader io.Reader, size int64, contentType string) (minio.UploadInfo, error) {
-	return s.client.PutObject(ctx, s.bucket, objectName, reader, size, minio.PutObjectOptions{ContentType: contentType})
-}
-
-func (s *minioStorage) PresignedGetURL(ctx context.Context, objectName string, expiry time.Duration) (string, error) {
+func (s *MinioStorage) PresignedGetURL(ctx context.Context, objectName string, expiry time.Duration) (string, error) {
 	reqParams := make(url.Values)
-	u, err := s.client.PresignedGetObject(ctx, s.bucket, objectName, expiry, reqParams)
+	u, err := s.internalClient.PresignedGetObject(ctx, s.bucket, objectName, expiry, reqParams)
 	if err != nil {
 		return "", err
 	}
 	return u.String(), nil
 }
 
-func (s *minioStorage) PresignedPutURL(ctx context.Context, objectName, contentType string, expiry time.Duration) (string, error) {
-	// Если есть отдельный клиент для presigned URL, используем его
-	if s.presignClient != nil {
-		u, err := s.presignClient.PresignedPutObject(ctx, s.bucket, objectName, expiry)
-		if err != nil {
-			return "", err
-		}
-		return u.String(), nil
-	}
-
-	// Фолбэк на основной клиент
-	u, err := s.client.PresignedPutObject(ctx, s.bucket, objectName, expiry)
+func (s *MinioStorage) PresignedPutURL(ctx context.Context, objectName, contentType string, expiry time.Duration) (string, error) {
+	u, err := s.externalClient.PresignedPutObject(ctx, s.bucket, objectName, expiry)
 	if err != nil {
 		return "", err
 	}
 	return u.String(), nil
 }
 
-func (s *minioStorage) Delete(ctx context.Context, objectName string) error {
-	return s.client.RemoveObject(ctx, s.bucket, objectName, minio.RemoveObjectOptions{})
+func (s *MinioStorage) Delete(ctx context.Context, objectName string) error {
+	return s.internalClient.RemoveObject(ctx, s.bucket, objectName, minio.RemoveObjectOptions{})
 }


### PR DESCRIPTION
…то согласно политики безоапсности S3, с которым minio имеет совместимость, не допускается предоставление адреса ссылки для файлов отличных от хоста, с которого зашли (данная ситуация возникает при исопльзовании докера, в котором мы можем внутри зайти и работать с minio, но ссылка для загрузки возвращается типа minio://, а нам надо с https://[хост]